### PR TITLE
Add AI Agents on EigenLayer AVS project

### DIFF
--- a/projects/ai-agents-on-eigenlayer-avs.md
+++ b/projects/ai-agents-on-eigenlayer-avs.md
@@ -1,0 +1,263 @@
+# AI Agents on EigenLayer AVS
+
+<aside>
+💡
+
+What if we could run AI agents with distributed trust and Ethereum-level security? 
+
+How can we leverage EigenLayer's restaking infrastructure to create a decentralized network of AI agents that are trustless, verifiable, and economically secured?
+
+</aside>
+
+## TL;DR (Verdict)
+
+Feasible and transformative for creating trust-minimized AI services. EigenLayer AVS provides the economic security and slashing mechanisms needed to ensure AI agents behave correctly. 
+
+The architecture would allow distributed nodes to run AI models with cryptographic verification (via TEE/ZKML/FHE), cross-validate outputs, and slash misbehaving operators. This creates the first truly decentralized AI infrastructure with Ethereum-level security guarantees.
+
+## What's an AVS in this context?
+
+AVS = Actively Validated Service (EigenLayer's term).
+
+It's like a specialized decentralized network where Ethereum validators opt in to also validate some extra service, not just Ethereum blocks.
+
+- Validators "restake" ETH (or LSTs) and run extra software — if they mess up, they can be slashed.
+- Instead of a single blockchain, AVSs can secure arbitrary off-chain or on-chain logic: oracles, bridges, ZK-provers, MPC networks… or AI agents.
+
+Think of it as: A "sidecar network" with Ethereum's security, custom rules, and slashing conditions.
+
+## AVS running AI agents — how it looks
+
+An AI-enabled AVS would be a distributed set of validator nodes that:
+
+- Run a local AI runtime (LLM, multi-modal model, or specialized AI agent)
+- Receive prompts/tasks from users or smart contracts
+- Produce AI outputs deterministically or with verifiable evidence
+- Cross-verify results between nodes to ensure honesty and correctness
+- Commit results on-chain (or return off-chain) with fraud proofs or cryptographic attestations
+
+### Architecture sketch:
+
+```
+[User / dApp] 
+    ↓ task request
+[AVS Gateway Smart Contract]
+    ↓
+[Validator Nodes with AI runtime] 
+   ↳ Model execution (locally or via enclave / FHE / ZKML)
+   ↳ Cross-node consensus on output
+    ↓
+[On-chain commit + payment]
+```
+
+## How it works in practice
+
+### A. Task flow
+
+1. **Request submission** → A dApp or contract sends a job to the AVS (e.g., "Summarize this DAO proposal" or "Classify on-chain transactions as MEV or not")
+
+2. **Job assignment** → AVS job scheduler picks a validator subset to run the AI task
+
+3. **Execution** → Each validator runs the model locally, possibly inside:
+   - TEE (Trusted Execution Environment) for privacy
+   - ZKML for provable correctness
+   - Encrypted computation via FHE
+
+4. **Consensus** → Validators compare outputs; if they match (within threshold), output is accepted
+
+5. **Settlement** → Result is returned to the requester; validators get paid; slashing occurs if results are invalid
+
+### B. Slashing conditions for AI agents
+
+- Providing an output that deviates from the majority (when the task is deterministic)
+- Failing to produce outputs on time
+- Proven model tampering or bias injection
+
+## Cool new things this could unlock
+
+### 🧠 On-chain AI Oracles
+
+AI that lives as part of Ethereum's trust layer, e.g.:
+- Interpret legal contracts into structured data for DAOs
+- Risk assessment for DeFi loans using both on-chain + off-chain market data
+- Classify NFTs by category, authenticity, or community relevance
+
+### 🔍 Trust-minimized AI fact-checkers
+
+- Distributed LLM network that verifies the accuracy of on-chain claims or social media posts before governance votes
+- No single provider can manipulate results — backed by Ethereum restakers
+
+### 🔐 Private AI Agents for DeFi
+
+- AVS with MPC/TEE-secured AI that executes private trading strategies on behalf of users
+- Inputs stay encrypted, but execution is still provably correct
+
+### ⚡ "Autonomous DAO Staff"
+
+- Proposal drafting, budgeting, and strategy suggestions for DAOs, validated by the AVS
+- Eliminates reliance on centralized DAO tooling vendors
+
+### 🎮 AI-powered game worlds
+
+- AVS nodes run AI NPCs in blockchain games, ensuring they behave fairly and persist state without central servers
+
+### 🌍 AI for Public Goods
+
+- Real-time climate or disaster prediction models whose outputs are paid for via quadratic funding pools
+- The AI runs as a commons service — governed and funded by the same network
+
+### 🧬 ZK-Proved AI model licensing
+
+- AVS nodes run proprietary AI models where execution is proven via ZK proofs — you pay per inference, but the model weights never leak
+
+## Why this is a big deal
+
+Right now, AI outputs are trusted because you trust OpenAI/Anthropic/etc.
+
+With AVSs, you could get:
+
+- **Distributed trust**: No single AI host
+- **Slashing-backed correctness**: Financial penalties for lying
+- **Cryptographic assurances**: ZK proofs that the exact model & prompt were run
+- **Ethereum-level security**: Inherited from restakers
+
+## Technical Implementation Details
+
+### Model Selection & Determinism
+
+**Challenge**: LLMs are often non-deterministic due to temperature settings and hardware variations.
+
+**Solutions**:
+- Use deterministic models with fixed seeds and temperature=0
+- Implement consensus on "fuzzy matching" for outputs (e.g., semantic similarity above threshold)
+- Use smaller, specialized models that are more predictable
+
+### Verification Methods
+
+1. **TEE-based** (Intel SGX, AMD SEV)
+   - Pros: Privacy-preserving, relatively mature
+   - Cons: Hardware trust assumptions, side-channel vulnerabilities
+
+2. **ZKML** (Zero-Knowledge Machine Learning)
+   - Pros: Cryptographic guarantees, no hardware trust
+   - Cons: High computational overhead, limited to smaller models currently
+
+3. **FHE** (Fully Homomorphic Encryption)
+   - Pros: Computation on encrypted data
+   - Cons: Extremely high overhead, early stage
+
+4. **Optimistic Verification**
+   - Run models normally, allow challenges with fraud proofs
+   - Similar to optimistic rollups but for AI outputs
+
+### Economic Model
+
+**Revenue streams**:
+- Per-inference fees from users
+- Subscription models for high-volume users
+- Token incentives for early operators
+
+**Cost structure**:
+- Hardware costs (GPUs/TPUs for operators)
+- Electricity and bandwidth
+- EigenLayer restaking opportunity cost
+
+**Slashing parameters**:
+- Minor deviation: 1% slash
+- Major deviation or timeout: 10% slash
+- Proven malicious behavior: 100% slash
+
+### AVS Operator Requirements
+
+**Hardware**:
+- Minimum GPU requirements (e.g., RTX 4090 or A100)
+- TEE-capable processors if using enclave approach
+- High-bandwidth internet connection
+
+**Software stack**:
+- EigenLayer AVS node software
+- AI runtime (PyTorch, TensorFlow, or custom)
+- Verification module (TEE/ZK prover)
+- Consensus client
+
+**Staking requirements**:
+- Minimum ETH stake (e.g., 32 ETH)
+- Or delegated stake from other restakers
+
+## Implementation Roadmap
+
+### Phase 1: MVP (3-4 months)
+- Simple classification tasks with small models
+- TEE-based verification
+- Basic slashing for timeouts and major deviations
+
+### Phase 2: Production (6-8 months)
+- Support for larger language models
+- ZKML integration for smaller models
+- Multi-model ensembles for better accuracy
+
+### Phase 3: Advanced (12+ months)
+- FHE support for private inputs
+- Custom model marketplace
+- Cross-AVS composability (AI + other services)
+
+## Security Considerations
+
+### Attack Vectors
+
+1. **Model poisoning**: Operators using tampered models
+   - Mitigation: Model hash verification, periodic attestations
+
+2. **Collusion**: Multiple operators coordinating false outputs
+   - Mitigation: Random operator selection, high collusion threshold
+
+3. **Data privacy leaks**: Extracting training data or inputs
+   - Mitigation: TEE/FHE, differential privacy techniques
+
+4. **Resource exhaustion**: Spam requests overwhelming operators
+   - Mitigation: Fee market, rate limiting, stake-weighted priority
+
+### Trust Assumptions
+
+- **EigenLayer security**: Inherits restaking risks and slashing mechanisms
+- **Hardware trust** (if using TEE): Intel/AMD attestation services
+- **Cryptographic assumptions** (if using ZK/FHE): Standard hardness assumptions
+
+## Comparison with Alternatives
+
+### Centralized AI APIs (OpenAI, Anthropic)
+- AI AVS wins on: Censorship resistance, verifiability, no single point of failure
+- Centralized wins on: Performance, cost efficiency, model quality
+
+### Other Decentralized AI (Bittensor, Render)
+- AI AVS wins on: Economic security via ETH restaking, Ethereum composability
+- Others win on: Specialized focus, existing networks
+
+### Blockchain-specific AI (Modulus, Ora)
+- AI AVS wins on: Flexibility, operator incentives via slashing
+- Others win on: Optimized for specific use cases
+
+## Open Questions & Research Areas
+
+1. **Optimal consensus mechanisms** for non-deterministic outputs
+2. **Standardized benchmarks** for AI AVS performance
+3. **Cross-chain AI requests** (from non-Ethereum chains)
+4. **Dynamic model updates** without breaking verification
+5. **Incentive design** for model creators vs operators
+
+## Getting Started
+
+For developers interested in building an AI AVS:
+
+1. Familiarize with [EigenLayer docs](https://docs.eigenlayer.xyz)
+2. Prototype with existing TEE frameworks (Gramine, Occlum)
+3. Experiment with ZKML libraries (EZKL, Remainder)
+4. Join EigenLayer developer community
+5. Apply for grants/support from EigenLayer ecosystem
+
+## Resources
+
+- [EigenLayer Whitepaper](https://eigenlayer.xyz/whitepaper)
+- [ZKML Resources](https://github.com/zkonduit/awesome-zkml)
+- [TEE Development Guide](https://gramine.readthedocs.io)
+- [FHE Libraries](https://github.com/zama-ai/concrete)


### PR DESCRIPTION
## Summary
Added a new project proposal for AI Agents running on EigenLayer AVS (Actively Validated Service).

## Description
This project explores how to create trust-minimized AI infrastructure by leveraging EigenLayer's restaking mechanism. The proposal covers:
- Architecture for distributed AI agent networks with economic security
- Various verification methods (TEE, ZKML, FHE)
- Use cases from AI oracles to autonomous DAO staff
- Implementation roadmap and security considerations

## Test plan
[x] Verified markdown formatting
[x] Checked consistency with other project documents in the repository

🤖 Generated with [Claude Code](https://claude.ai/code)